### PR TITLE
switching to compact layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ function mapLen<K, V>(tree: TernaryTreeMap<K, V>): number;
 function isMapEmpty<K, V>(tree: TernaryTreeMap<K, V>): boolean;
 function contains<K, T>(tree: TernaryTreeMap<K, T>, item: K, hx: Hash = null as any): boolean;
 function mapEqual<K, V>(xs: TernaryTreeMap<K, V>, ys: TernaryTreeMap<K, V>): boolean;
-function mapGet<K, T>(originalTree: TernaryTreeMap<K, T>, item: K): T;
 
 function* toPairs<K, T>(tree: TernaryTreeMap<K, T>): Generator<[K, T]>;
 function* toKeys<K, V>(tree: TernaryTreeMap<K, V>): Generator<K>;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcit/ternary-tree",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "main": "./lib/index.js",
   "devDependencies": {
     "prettier": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcit/ternary-tree",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "main": "./lib/index.js",
   "devDependencies": {
     "prettier": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcit/ternary-tree",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "main": "./lib/index.js",
   "devDependencies": {
     "prettier": "^2.2.1",

--- a/src/map.ts
+++ b/src/map.ts
@@ -383,39 +383,63 @@ export function contains<K, T>(originalTree: TernaryTreeMap<K, T>, item: K): boo
       return false;
     }
     if (tree.left.kind === TernaryTreeKind.ternaryTreeLeaf) {
+      if (hx < tree.left.hash) {
+        return false;
+      }
       if (tree.left.hash === hx) {
         tree = tree.left;
         continue whileLoop; // notice, it jumps to while loop
       }
-    } else if (hx >= tree.left.minHash && hx <= tree.left.maxHash) {
-      tree = tree.left;
-      continue whileLoop; // notice, it jumps to while loop
+    } else {
+      if (hx < tree.left.minHash) {
+        return false;
+      }
+      if (hx <= tree.left.maxHash) {
+        tree = tree.left;
+        continue whileLoop; // notice, it jumps to while loop
+      }
     }
 
     if (tree.middle == null) {
       return false;
     }
     if (tree.middle.kind === TernaryTreeKind.ternaryTreeLeaf) {
+      if (hx < tree.middle.hash) {
+        return false;
+      }
       if (tree.middle.hash === hx) {
         tree = tree.middle;
         continue whileLoop; // notice, it jumps to while loop
       }
-    } else if (hx >= tree.middle.minHash && hx <= tree.middle.maxHash) {
-      tree = tree.middle;
-      continue whileLoop; // notice, it jumps to while loop
+    } else {
+      if (hx < tree.middle.minHash) {
+        return false;
+      }
+      if (hx <= tree.middle.maxHash) {
+        tree = tree.middle;
+        continue whileLoop; // notice, it jumps to while loop
+      }
     }
 
     if (tree.right == null) {
       return false;
     }
     if (tree.right.kind === TernaryTreeKind.ternaryTreeLeaf) {
+      if (hx < tree.right.hash) {
+        return false;
+      }
       if (tree.right.hash === hx) {
         tree = tree.right;
         continue whileLoop; // notice, it jumps to while loop
       }
-    } else if (hx >= tree.right.minHash && hx <= tree.right.maxHash) {
-      tree = tree.right;
-      continue whileLoop; // notice, it jumps to while loop
+    } else {
+      if (hx < tree.right.minHash) {
+        return false;
+      }
+      if (hx <= tree.right.maxHash) {
+        tree = tree.right;
+        continue whileLoop; // notice, it jumps to while loop
+      }
     }
     return false;
   }
@@ -423,68 +447,6 @@ export function contains<K, T>(originalTree: TernaryTreeMap<K, T>, item: K): boo
   return false;
 }
 
-export function mapGet<K, T>(originalTree: TernaryTreeMap<K, T>, item: K): T {
-  let hx = hashGenerator(item);
-
-  let tree = originalTree;
-
-  whileLoop: while (tree != null) {
-    if (tree.kind === TernaryTreeKind.ternaryTreeLeaf) {
-      let size = tree.elements.length;
-      for (let i = 0; i < size; i++) {
-        let pair = tree.elements[i];
-        if (dataEqual(pair[0], item)) {
-          return pair[1];
-        }
-      }
-      throw new Error(`Cannot find target for ${item}`);
-    }
-
-    // echo "looking for: ", hx, " ", item, " in ", tree.formatInline
-
-    if (tree.left == null) {
-      throw new Error(`Cannot find target for ${item}`);
-    }
-    if (tree.left.kind == TernaryTreeKind.ternaryTreeLeaf) {
-      if (tree.left.hash === hx) {
-        tree = tree.left;
-        continue whileLoop; // notice, it jumps to while loop
-      }
-    } else if (hx >= tree.left.minHash && hx <= tree.left.maxHash) {
-      tree = tree.left;
-      continue whileLoop; // notice, it jumps to while loop
-    }
-
-    if (tree.middle == null) {
-      throw new Error(`Cannot find target for ${item}`);
-    }
-    if (tree.middle.kind == TernaryTreeKind.ternaryTreeLeaf) {
-      if (tree.middle.hash === hx) {
-        tree = tree.middle;
-        continue whileLoop; // notice, it jumps to while loop
-      }
-    } else if (hx >= tree.middle.minHash && hx <= tree.middle.maxHash) {
-      tree = tree.middle;
-      continue whileLoop; // notice, it jumps to while loop
-    }
-    if (tree.right == null) {
-      throw new Error(`Cannot find target for ${item}`);
-    }
-    if (tree.right.kind == TernaryTreeKind.ternaryTreeLeaf) {
-      if (tree.right.hash === hx) {
-        tree = tree.right;
-        continue whileLoop; // notice, it jumps to while loop
-      }
-    } else if (hx >= tree.right.minHash && hx <= tree.right.maxHash) {
-      tree = tree.right;
-      continue whileLoop; // notice, it jumps to while loop
-    }
-
-    throw new Error(`Cannot find target for ${item}`);
-  }
-
-  throw new Error(`Cannot find target for ${item}`);
-}
 export function mapGetDefault<K, T>(originalTree: TernaryTreeMap<K, T>, item: K, v0: T): T {
   let hx = hashGenerator(item);
 
@@ -508,39 +470,63 @@ export function mapGetDefault<K, T>(originalTree: TernaryTreeMap<K, T>, item: K,
       return v0;
     }
     if (tree.left.kind == TernaryTreeKind.ternaryTreeLeaf) {
+      if (hx < tree.left.hash) {
+        return v0;
+      }
       if (tree.left.hash === hx) {
         tree = tree.left;
         continue whileLoop; // notice, it jumps to while loop
       }
-    } else if (hx >= tree.left.minHash && hx <= tree.left.maxHash) {
-      tree = tree.left;
-      continue whileLoop; // notice, it jumps to while loop
+    } else {
+      if (hx < tree.left.minHash) {
+        return v0;
+      }
+      if (hx <= tree.left.maxHash) {
+        tree = tree.left;
+        continue whileLoop; // notice, it jumps to while loop
+      }
     }
 
     if (tree.middle == null) {
       return v0;
     }
     if (tree.middle.kind == TernaryTreeKind.ternaryTreeLeaf) {
+      if (hx < tree.middle.hash) {
+        return v0;
+      }
       if (tree.middle.hash === hx) {
         tree = tree.middle;
         continue whileLoop; // notice, it jumps to while loop
       }
-    } else if (hx >= tree.middle.minHash && hx <= tree.middle.maxHash) {
-      tree = tree.middle;
-      continue whileLoop; // notice, it jumps to while loop
+    } else {
+      if (hx < tree.middle.minHash) {
+        return v0;
+      }
+      if (hx <= tree.middle.maxHash) {
+        tree = tree.middle;
+        continue whileLoop; // notice, it jumps to while loop
+      }
     }
 
     if (tree.right == null) {
       return v0;
     }
     if (tree.right.kind == TernaryTreeKind.ternaryTreeLeaf) {
+      if (hx < tree.right.hash) {
+        return v0;
+      }
       if (tree.right.hash === hx) {
         tree = tree.right;
         continue whileLoop; // notice, it jumps to while loop
       }
-    } else if (hx >= tree.right.minHash && hx <= tree.right.maxHash) {
-      tree = tree.right;
-      continue whileLoop; // notice, it jumps to while loop
+    } else {
+      if (hx < tree.right.minHash) {
+        return v0;
+      }
+      if (hx <= tree.right.maxHash) {
+        tree = tree.right;
+        continue whileLoop; // notice, it jumps to while loop
+      }
     }
 
     return v0;
@@ -1200,9 +1186,14 @@ export function mapEqual<K, V>(xs: TernaryTreeMap<K, V>, ys: TernaryTreeMap<K, V
     return true;
   }
 
-  for (let key of toKeys(xs)) {
-    let vx = mapGet(xs, key);
-    let vy = mapGet(ys, key);
+  for (let pair of toPairsArray(xs)) {
+    let key = pair[0];
+    let vx = pair[1];
+
+    if (!contains(ys, key)) {
+      return false;
+    }
+    let vy = mapGetDefault(ys, key, null);
 
     // TODO compare deep structures
     if (!dataEqual(vx, vy)) {

--- a/src/map.ts
+++ b/src/map.ts
@@ -70,15 +70,7 @@ function createLeafFromHashEntry<K, T>(item: TernaryTreeMapHashEntry<K, T>): Ter
 function makeTernaryTreeMap<K, T>(size: number, offset: number, xs: /* var */ Array<TernaryTreeMapHashEntry<K, T>>): TernaryTreeMap<K, T> {
   switch (size) {
     case 0: {
-      let result: TernaryTreeMapTheBranch<K, T> = {
-        kind: TernaryTreeKind.ternaryTreeBranch,
-        maxHash: 0,
-        minHash: 0,
-        left: emptyBranch,
-        middle: emptyBranch,
-        right: emptyBranch,
-        depth: 0,
-      };
+      let result: TernaryTreeMap<K, T> = emptyBranch;
       return result;
     }
     case 1: {
@@ -178,15 +170,7 @@ export function initTernaryTreeMap<K, T>(t: Map<K, T> | Array<[K, T]>): TernaryT
 
 // for empty map
 export function initEmptyTernaryTreeMap<K, T>(): TernaryTreeMap<K, T> {
-  let result: TernaryTreeMapTheBranch<K, T> = {
-    kind: TernaryTreeKind.ternaryTreeBranch,
-    maxHash: 0,
-    minHash: 0,
-    left: emptyBranch,
-    middle: emptyBranch,
-    right: emptyBranch,
-    depth: 0,
-  };
+  let result: TernaryTreeMap<K, T> = emptyBranch;
   return result;
 }
 
@@ -718,9 +702,9 @@ function assocNew<K, T>(tree: TernaryTreeMap<K, T>, key: K, item: T, thisHash: H
           kind: TernaryTreeKind.ternaryTreeBranch,
           maxHash: thisHash,
           minHash: tree.hash,
-          left: emptyBranch,
-          middle: tree,
-          right: childBranch,
+          left: tree,
+          middle: childBranch,
+          right: emptyBranch,
           depth: 0, // TODO
         };
         return result;

--- a/src/map.ts
+++ b/src/map.ts
@@ -83,15 +83,7 @@ function makeTernaryTreeMap<K, T>(size: number, offset: number, xs: /* var */ Ar
     }
     case 1: {
       let leftPair = xs[offset];
-      let result: TernaryTreeMap<K, T> = {
-        kind: TernaryTreeKind.ternaryTreeBranch,
-        maxHash: leftPair.hash,
-        minHash: leftPair.hash,
-        left: createLeafFromHashEntry(leftPair),
-        right: emptyBranch,
-        middle: emptyBranch,
-        depth: 1,
-      };
+      let result: TernaryTreeMap<K, T> = createLeafFromHashEntry(leftPair);
       return result;
     }
     case 2: {
@@ -979,6 +971,9 @@ function dissocExisted<K, T>(tree: TernaryTreeMap<K, T>, key: K): TernaryTreeMap
     }
 
     if (isMapEmpty(changedBranch)) {
+      if (isMapEmpty(tree.right)) {
+        return tree.middle;
+      }
       let result: TernaryTreeMapTheBranch<K, T> = {
         kind: TernaryTreeKind.ternaryTreeBranch,
         maxHash: tree.maxHash,
@@ -1007,6 +1002,9 @@ function dissocExisted<K, T>(tree: TernaryTreeMap<K, T>, key: K): TernaryTreeMap
     let changedBranch = dissocExisted(tree.middle, key);
 
     if (isMapEmpty(changedBranch)) {
+      if (isMapEmpty(tree.right)) {
+        return tree.left;
+      }
       let result: TernaryTreeMapTheBranch<K, T> = {
         kind: TernaryTreeKind.ternaryTreeBranch,
         maxHash: getMax(tree),

--- a/src/test-list.ts
+++ b/src/test-list.ts
@@ -31,7 +31,7 @@ import {
   listMapValues,
 } from "./list";
 
-import { test, check, arrayEqual } from "./utils";
+import { test, check, arrayEqual, checkEqual } from "./utils";
 
 export let runListTests = () => {
   test("init list", () => {
@@ -46,7 +46,7 @@ export let runListTests = () => {
 
     check(checkListStructure(data11));
 
-    check(formatListInline(data11) === "((1 (2 _ 3) 4) (5 6 7) (8 (9 _ 10) 11))");
+    checkEqual(formatListInline(data11), "((1 (2 3 _) 4) (5 6 7) (8 (9 10 _) 11))");
     check(
       arrayEqual<number>(origin11, [...listToItems(data11)])
     );
@@ -82,51 +82,51 @@ export let runListTests = () => {
       check(listLen(dissocList(data5, idx)) === listLen(data5) - 1);
     }
 
-    check(formatListInline(data5) === "((1 _ 2) 3 (4 _ 5))");
-    check(formatListInline(dissocList(data5, 0)) === "(2 3 (4 _ 5))");
-    check(formatListInline(dissocList(data5, 1)) === "(1 3 (4 _ 5))");
-    check(formatListInline(dissocList(data5, 2)) === "((1 _ 2) _ (4 _ 5))");
-    check(formatListInline(dissocList(data5, 3)) === "((1 _ 2) 3 5)");
-    check(formatListInline(dissocList(data5, 4)) === "((1 _ 2) 3 4)");
+    checkEqual(formatListInline(data5), "((1 2 _) 3 (4 5 _))");
+    checkEqual(formatListInline(dissocList(data5, 0)), "(2 3 (4 5 _))");
+    checkEqual(formatListInline(dissocList(data5, 1)), "(1 3 (4 5 _))");
+    checkEqual(formatListInline(dissocList(data5, 2)), "((1 2 _) (4 5 _) _)");
+    checkEqual(formatListInline(dissocList(data5, 3)), "((1 2 _) 3 5)");
+    checkEqual(formatListInline(dissocList(data5, 4)), "((1 2 _) 3 4)");
 
-    check(formatListInline(rest(initTernaryTreeList([1]))) === "(_ _ _)");
-    check(formatListInline(rest(initTernaryTreeList([1, 2]))) === "2");
-    check(formatListInline(rest(initTernaryTreeList([1, 2, 3]))) === "(_ 2 3)");
-    check(formatListInline(rest(initTernaryTreeList([1, 2, 3, 4]))) === "(_ (2 _ 3) 4)");
-    check(formatListInline(rest(initTernaryTreeList([1, 2, 3, 4, 5]))) === "(2 3 (4 _ 5))");
+    checkEqual(formatListInline(rest(initTernaryTreeList([1]))), "_");
+    checkEqual(formatListInline(rest(initTernaryTreeList([1, 2]))), "2");
+    checkEqual(formatListInline(rest(initTernaryTreeList([1, 2, 3]))), "(2 3 _)");
+    checkEqual(formatListInline(rest(initTernaryTreeList([1, 2, 3, 4]))), "((2 3 _) 4 _)");
+    checkEqual(formatListInline(rest(initTernaryTreeList([1, 2, 3, 4, 5]))), "(2 3 (4 5 _))");
 
-    check(formatListInline(butlast(initTernaryTreeList([1]))) === "(_ _ _)");
-    check(formatListInline(butlast(initTernaryTreeList([1, 2]))) === "1");
-    check(formatListInline(butlast(initTernaryTreeList([1, 2, 3]))) === "(1 2 _)");
-    check(formatListInline(butlast(initTernaryTreeList([1, 2, 3, 4]))) === "(1 (2 _ 3) _)");
-    check(formatListInline(butlast(initTernaryTreeList([1, 2, 3, 4, 5]))) === "((1 _ 2) 3 4)");
+    checkEqual(formatListInline(butlast(initTernaryTreeList([1]))), "_");
+    checkEqual(formatListInline(butlast(initTernaryTreeList([1, 2]))), "1");
+    checkEqual(formatListInline(butlast(initTernaryTreeList([1, 2, 3]))), "(1 2 _)");
+    checkEqual(formatListInline(butlast(initTernaryTreeList([1, 2, 3, 4]))), "(1 (2 3 _) _)");
+    checkEqual(formatListInline(butlast(initTernaryTreeList([1, 2, 3, 4, 5]))), "((1 2 _) 3 4)");
   });
 
   test("list insertions", () => {
     let origin5 = [1, 2, 3, 4, 5];
     let data5 = initTernaryTreeList(origin5);
 
-    check(formatListInline(data5) === "((1 _ 2) 3 (4 _ 5))");
+    checkEqual(formatListInline(data5), "((1 2 _) 3 (4 5 _))");
 
-    check(formatListInline(insert(data5, 0, 10, false)) === "(_ 10 ((1 _ 2) 3 (4 _ 5)))");
-    check(formatListInline(insert(data5, 0, 10, true)) === "((1 10 2) 3 (4 _ 5))");
-    check(formatListInline(insert(data5, 1, 10, false)) === "((1 10 2) 3 (4 _ 5))");
-    check(formatListInline(insert(data5, 1, 10, true)) === "((1 2 10) 3 (4 _ 5))");
-    check(formatListInline(insert(data5, 2, 10, false)) === "((1 _ 2) (_ 10 3) (4 _ 5))");
-    check(formatListInline(insert(data5, 2, 10, true)) === "((1 _ 2) (3 10 _) (4 _ 5))");
-    check(formatListInline(insert(data5, 3, 10, false)) === "((1 _ 2) 3 (10 4 5))");
-    check(formatListInline(insert(data5, 3, 10, true)) === "((1 _ 2) 3 (4 10 5))");
-    check(formatListInline(insert(data5, 4, 10, false)) === "((1 _ 2) 3 (4 10 5))");
-    check(formatListInline(insert(data5, 4, 10, true)) === "(((1 _ 2) 3 (4 _ 5)) 10 _)");
+    checkEqual(formatListInline(insert(data5, 0, 10, false)), "(10 ((1 2 _) 3 (4 5 _)) _)");
+    checkEqual(formatListInline(insert(data5, 0, 10, true)), "((1 10 2) 3 (4 5 _))");
+    checkEqual(formatListInline(insert(data5, 1, 10, false)), "((1 10 2) 3 (4 5 _))");
+    checkEqual(formatListInline(insert(data5, 1, 10, true)), "((1 2 10) 3 (4 5 _))");
+    checkEqual(formatListInline(insert(data5, 2, 10, false)), "((1 2 _) (10 3 _) (4 5 _))");
+    checkEqual(formatListInline(insert(data5, 2, 10, true)), "((1 2 _) (3 10 _) (4 5 _))");
+    checkEqual(formatListInline(insert(data5, 3, 10, false)), "((1 2 _) 3 (10 4 5))");
+    checkEqual(formatListInline(insert(data5, 3, 10, true)), "((1 2 _) 3 (4 10 5))");
+    checkEqual(formatListInline(insert(data5, 4, 10, false)), "((1 2 _) 3 (4 10 5))");
+    checkEqual(formatListInline(insert(data5, 4, 10, true)), "(((1 2 _) 3 (4 5 _)) 10 _)");
 
     let origin4 = [1, 2, 3, 4];
     let data4 = initTernaryTreeList(origin4);
 
-    check(formatListInline(assocBefore(data4, 3, 10)) === "(1 (2 _ 3) (_ 10 4))");
-    check(formatListInline(assocAfter(data4, 3, 10)) === "(1 (2 _ 3) (4 10 _))");
+    checkEqual(formatListInline(assocBefore(data4, 3, 10)), "(1 (2 3 _) (10 4 _))");
+    checkEqual(formatListInline(assocAfter(data4, 3, 10)), "(1 (2 3 _) (4 10 _))");
 
-    check(formatListInline(prepend(data4, 10)) === "((_ 10 1) (2 _ 3) 4)");
-    check(formatListInline(append(data4, 10)) === "(1 (2 _ 3) (4 10 _))");
+    checkEqual(formatListInline(prepend(data4, 10)), "((10 1 _) (2 3 _) 4)");
+    checkEqual(formatListInline(append(data4, 10)), "(1 (2 3 _) (4 10 _))");
   });
 
   test("concat", () => {
@@ -136,10 +136,10 @@ export let runListTests = () => {
     let data3 = initTernaryTreeList([5, 6]);
     let data4 = initTernaryTreeList([7, 8]);
 
-    check(formatListInline(concat(data1, data2)) === "((1 _ 2) _ (3 _ 4))");
-    check(formatListInline(concat(initTernaryTreeList<number>([]), data1)) === "(1 _ 2)");
-    check(formatListInline(concat(data1, data2, data3)) === "((1 _ 2) (3 _ 4) (5 _ 6))");
-    check(formatListInline(concat(data1, data2, data3, data4)) === "((1 _ 2) ((3 _ 4) _ (5 _ 6)) (7 _ 8))");
+    check(formatListInline(concat(data1, data2)) === "((1 2 _) (3 4 _) _)");
+    check(formatListInline(concat(initTernaryTreeList<number>([]), data1)) === "(1 2 _)");
+    check(formatListInline(concat(data1, data2, data3)) === "((1 2 _) (3 4 _) (5 6 _))");
+    check(formatListInline(concat(data1, data2, data3, data4)) === "((1 2 _) ((3 4 _) (5 6 _) _) (7 8 _))");
 
     checkListStructure(concat(data1, data2));
     checkListStructure(concat(data1, data2, data3));
@@ -172,7 +172,7 @@ export let runListTests = () => {
     // echo data.formatInline
     check(formatListInline(data) === "(((0 1 2) (3 4 5) (6 7 8)) ((9 10 11) (12 13 14) (15 16 17)) (18 19 _))");
     forceListInplaceBalancing(data);
-    check(formatListInline(data) === "(((0 _ 1) (2 3 4) (5 _ 6)) ((7 _ 8) (9 _ 10) (11 _ 12)) ((13 _ 14) (15 16 17) (18 _ 19)))");
+    check(formatListInline(data) === "(((0 1 _) (2 3 4) (5 6 _)) ((7 8 _) (9 10 _) (11 12 _)) ((13 14 _) (15 16 17) (18 19 _)))");
     // echo data.formatInline
   });
 

--- a/src/test-list.ts
+++ b/src/test-list.ts
@@ -195,7 +195,7 @@ export let runListTests = () => {
     check(i === 6);
   });
 
-  test("check(structure)", () => {
+  test("check structure", () => {
     var data = initTernaryTreeList<number>([]);
     for (let idx = 0; idx < 20; idx++) {
       data = append(data, idx, true);

--- a/src/test-map.ts
+++ b/src/test-map.ts
@@ -61,6 +61,19 @@ export let runMapTests = () => {
     check(mapEqual(initEmptyTernaryTreeMap<string, number>(), initTernaryTreeMap(emptyData)));
   });
 
+  test("assoc and contains", () => {
+    var dict: Map<string, number> = new Map();
+    for (let idx = 0; idx < 100; idx++) {
+      dict.set(`${idx * 2}`, idx);
+    }
+    let data = initTernaryTreeMap(dict);
+    for (let idx = 0; idx < 100; idx++) {
+      dict.set(`${idx * 2 + 1}`, idx);
+      let data2 = assocMap(data, `${idx * 2 + 1}`, idx);
+      check(contains(data2, `${idx * 2 + 1}`));
+    }
+  });
+
   test("check structure", () => {
     var dict: Map<string, number> = new Map();
     for (let idx = 0; idx < 100; idx++) {

--- a/src/test-map.ts
+++ b/src/test-map.ts
@@ -45,7 +45,7 @@ export let runMapTests = () => {
     checkMapStructure(data11);
 
     // echo data10
-    justDisplay(formatMapInline(data10), "((2:12 3:13 7:17) ((_ 9:19 _) (6:16 _ 5:15) (_ 1:11 _)) (8:18 0:10 4:14))");
+    justDisplay(formatMapInline(data10, true), " ((0:10 1:11 2:12) (3:13 (4:14 5:15 _) 6:16) (7:17 8:18 9:19))");
 
     check(deepEqual(toHashSortedPairs(data10), inList));
     check(deepEqual(toHashSortedPairs(data11), inList));
@@ -86,8 +86,8 @@ export let runMapTests = () => {
     check(contains(data, "12") == false);
     checkMapStructure(data);
 
-    justDisplay(formatMapInline(assocMap(data, "1", 2222), false), "((2:12 3:13 7:17) ((_ 9:19 _) (6:16 _ 5:15) (_ 1:2222 _)) (8:18 0:10 4:14))");
-    justDisplay(formatMapInline(assocMap(data, "23", 2222), false), "((2:12 3:13 7:17) ((_ 9:19 _) (6:16 _ 5:15) (23:2222 1:11 _)) (8:18 0:10 4:14))");
+    justDisplay(formatMapInline(assocMap(data, "1", 2222), true), "((0:10 1:2222 2:12) (3:13 (4:14 5:15 _) 6:16) (7:17 8:18 9:19))");
+    justDisplay(formatMapInline(assocMap(data, "23", 2222), true), "(((0:10 1:11 2:12) (3:13 (4:14 5:15 _) 6:16) (7:17 8:18 9:19)) 23:2222 _)");
   });
 
   test("dissoc", () => {

--- a/src/test-map.ts
+++ b/src/test-map.ts
@@ -42,6 +42,8 @@ export let runMapTests = () => {
 
     let data10 = initTernaryTreeMap<string, number>(dict);
     let data11 = initTernaryTreeMap<string, number>(inList);
+    checkMapStructure(data10);
+    checkMapStructure(data11);
 
     // echo data10
     justDisplay(formatMapInline(data10), "((2:12 3:13 7:17) ((_ 9:19 _) (6:16 _ 5:15) (_ 1:11 _)) (8:18 0:10 4:14))");
@@ -60,7 +62,7 @@ export let runMapTests = () => {
     check(mapEqual(initEmptyTernaryTreeMap<string, number>(), initTernaryTreeMap(emptyData)));
   });
 
-  test("check(structure", () => {
+  test("check structure", () => {
     var dict: Map<string, number> = new Map();
     for (let idx = 0; idx < 100; idx++) {
       dict.set(`${idx}`, idx + 10);
@@ -83,6 +85,7 @@ export let runMapTests = () => {
 
     check(contains(data, "1") == true);
     check(contains(data, "12") == false);
+    checkMapStructure(data);
 
     justDisplay(formatMapInline(assocMap(data, "1", 2222), false), "((2:12 3:13 7:17) ((_ 9:19 _) (6:16 _ 5:15) (_ 1:2222 _)) (8:18 0:10 4:14))");
     justDisplay(formatMapInline(assocMap(data, "23", 2222), false), "((2:12 3:13 7:17) ((_ 9:19 _) (6:16 _ 5:15) (23:2222 1:11 _)) (8:18 0:10 4:14))");
@@ -95,6 +98,7 @@ export let runMapTests = () => {
     }
 
     let data = initTernaryTreeMap(dict);
+    checkMapStructure(data);
 
     // echo data.formatInline
 
@@ -119,6 +123,7 @@ export let runMapTests = () => {
     }
 
     let data = initTernaryTreeMap(dict);
+    checkMapStructure(data);
 
     // TODO
     // justDisplay((mapToString(toPairs(data))) , "@[2:12, 3:13, 7:17, 9:19, 6:16, 5:15, 1:11, 8:18, 0:10, 4:14]")
@@ -135,6 +140,8 @@ export let runMapTests = () => {
 
     let data = initTernaryTreeMap(dict);
     let b = dissocMap(data, "3");
+    checkMapStructure(data);
+    checkMapStructure(b);
 
     check(mapEqual(data, data));
     check(!mapEqual(data, b));
@@ -158,6 +165,7 @@ export let runMapTests = () => {
     }
 
     let data = initTernaryTreeMap(dict);
+    checkMapStructure(data);
 
     var dictB: Map<string, number> = new Map();
     for (let idx = 10; idx < 14; idx++) {
@@ -178,12 +186,14 @@ export let runMapTests = () => {
       dict.set(`${idx}`, idx + 10);
     }
     let a = initTernaryTreeMap(dict);
+    checkMapStructure(a);
 
     var dict2: Map<string, number> = new Map();
     for (let idx = 0; idx < 4; idx++) {
       dict2.set(`${idx}`, idx + 11);
     }
     let b = initTernaryTreeMap(dict2);
+    checkMapStructure(b);
 
     let c = mergeSkip(a, b, 11);
     check(deepEqual(mapGet(c, "0"), 10));
@@ -201,6 +211,7 @@ export let runMapTests = () => {
     }
 
     let data = initTernaryTreeMap(dict);
+    checkMapStructure(data);
 
     var i = 0;
     for (let [k, v] of toPairs(data)) {
@@ -223,6 +234,7 @@ export let runMapTests = () => {
     }
 
     let data = initTernaryTreeMap(dict);
+    checkMapStructure(data);
 
     var i = 0;
     for (let [k, v] of toPairs(data)) {
@@ -246,6 +258,7 @@ export let runMapTests = () => {
     let data2 = initTernaryTreeMap(dict2);
 
     let data3 = mapMapValues(data, (x) => x + 10);
+    checkMapStructure(data3);
 
     checkMapStructure(data3);
     check(mapEqual(data2, data3));

--- a/src/test-map.ts
+++ b/src/test-map.ts
@@ -72,6 +72,14 @@ export let runMapTests = () => {
       let data2 = assocMap(data, `${idx * 2 + 1}`, idx);
       check(contains(data2, `${idx * 2 + 1}`));
     }
+
+    var dict: Map<string, number> = new Map();
+    data = initTernaryTreeMap(dict);
+    for (let idx = 0; idx < 1000; idx++) {
+      let p = 100 - idx / 10;
+      data = assocMap(data, `${p}`, idx);
+      check(contains(data, `${p}`));
+    }
   });
 
   test("check structure", () => {

--- a/src/test-map.ts
+++ b/src/test-map.ts
@@ -10,7 +10,6 @@ import {
   assocMap,
   dissocMap,
   contains,
-  mapGet,
   toPairs,
   initEmptyTernaryTreeMap,
   sameMapShape,
@@ -54,9 +53,9 @@ export let runMapTests = () => {
     check(contains(data10, "1") == true);
     check(contains(data10, "11") == false);
 
-    check(deepEqual(mapGet(data10, "1"), 11));
+    check(deepEqual(mapGetDefault(data10, "1", null), 11));
     check(deepEqual(mapGetDefault(data10, "111", 0), 0));
-    // check(deepEqual(mapGet(data10, "11"), null)); // should throws error
+    // check(deepEqual(mapGetDefault(data10, "11", {} as any), null)); // should throws error
 
     let emptyData: Map<string, number> = new Map();
     check(mapEqual(initEmptyTernaryTreeMap<string, number>(), initTernaryTreeMap(emptyData)));
@@ -196,10 +195,10 @@ export let runMapTests = () => {
     checkMapStructure(b);
 
     let c = mergeSkip(a, b, 11);
-    check(deepEqual(mapGet(c, "0"), 10));
-    check(deepEqual(mapGet(c, "1"), 12));
-    check(deepEqual(mapGet(c, "2"), 13));
-    check(deepEqual(mapGet(c, "3"), 14));
+    check(deepEqual(mapGetDefault(c, "0", null), 10));
+    check(deepEqual(mapGetDefault(c, "1", null), 12));
+    check(deepEqual(mapGetDefault(c, "2", null), 13));
+    check(deepEqual(mapGetDefault(c, "3", null), 14));
   });
 
   test("iterator", () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -67,6 +67,16 @@ export let check = (x: boolean): void => {
     throw new Error("Test failed");
   }
 };
+
+/** compare by reference */
+export let checkEqual = (x: any, y: any): void => {
+  if (x !== y) {
+    console.log("Left:  ", x);
+    console.log("Right: ", y);
+    throw new Error("Test failed");
+  }
+};
+
 export let justDisplay = (x: any, y: any): void => {
   console.group("Compare:");
   console.log(x);


### PR DESCRIPTION
`mapGet` function has been removed, it was not used actually.

In this change, "holes" are now placed at end, so there are fewer cases to handle.

Current version should be smilar to https://github.com/hdgarrood/purescript-sequences/blob/master/src/Data/FingerTree.purs despite the lack of algebraic data types.
